### PR TITLE
Update TLS usage for corosio tls_role and stream-hostname API

### DIFF
--- a/src/detail/connection_pool.cpp
+++ b/src/detail/connection_pool.cpp
@@ -23,11 +23,13 @@
 #include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/corosio/timeout.hpp>
+#include <boost/corosio/tls_stream.hpp>
 #include <boost/url/scheme.hpp>
 #include <boost/url/url_view.hpp>
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace boost
@@ -123,7 +125,13 @@ public:
     capy::io_task<>
     handshake()
     {
-        return stream_.handshake(corosio::openssl_stream::client);
+        return stream_.handshake(corosio::tls_role::client);
+    }
+
+    void
+    set_hostname(std::string_view hostname)
+    {
+        stream_.set_hostname(hostname);
     }
 
     bool
@@ -361,11 +369,9 @@ connection_pool::connect(urls::url_view url) const
 
     if(url.scheme_id() == scheme::https)
     {
-        auto tls_ctx = tls_ctx_;
-        tls_ctx.set_hostname(url.encoded_host());
-
         auto conn =
-            std::make_unique<tls_connection>(std::move(socket), tls_ctx);
+            std::make_unique<tls_connection>(std::move(socket), tls_ctx_);
+        conn->set_hostname(url.encoded_host());
         auto [hec] = co_await conn->handshake();
         if(hec)
             co_return { hec, {} };

--- a/test/unit/detail/connection_pool.cpp
+++ b/test/unit/detail/connection_pool.cpp
@@ -23,6 +23,7 @@
 #include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <boost/corosio/tls_context.hpp>
+#include <boost/corosio/tls_stream.hpp>
 
 #include "scripted_net.hpp"
 #include "test_suite.hpp"
@@ -486,7 +487,7 @@ public:
         {
             corosio::openssl_stream s{ co_await server.next(), tls_ctx };
             auto [hec] = co_await s.handshake(
-                corosio::openssl_stream::server);
+                corosio::tls_role::server);
             BOOST_TEST(!hec);
 
             co_await pong(&s);


### PR DESCRIPTION
corosio replaced openssl_stream's handshake_type with a tls_role enum and moved hostname configuration from tls_context to the stream.

- handshake(openssl_stream::client/server) -> handshake(tls_role::client/server)
- configure the SNI/verify hostname on the stream: tls_connection gains a set_hostname() forwarding to openssl_stream::set_hostname, called on the connection before handshake, instead of mutating a per-connection tls_context copy
- include <boost/corosio/tls_stream.hpp> for tls_role