### PR TITLE
refactor: use the transfer algorithms and source/sink types from http

### DIFF
--- a/doc/modules/ROOT/pages/2.guide/2n.extending.adoc
+++ b/doc/modules/ROOT/pages/2.guide/2n.extending.adoc
@@ -27,7 +27,7 @@ struct MyRequestBody
 {
     std::optional<std::string>   content_type()   const;
     std::optional<std::uint64_t> content_length() const;
-    capy::io_task<>              write(capy::any_buffer_sink& sink) const;
+    capy::io_task<>              write(http::any_buffer_sink& sink) const;
 };
 ----
 

--- a/example/nlohmann_json.cpp
+++ b/example/nlohmann_json.cpp
@@ -49,7 +49,7 @@ tag_invoke(burl::body_from_tag<nlohmann::json>, const nlohmann::json& value)
         }
 
         capy::io_task<>
-        write(capy::any_buffer_sink& sink) const
+        write(http::any_buffer_sink& sink) const
         {
             auto [ec, n] = co_await sink.write_eof(capy::make_buffer(text_));
             co_return { ec };

--- a/include/boost/burl/any_request_body.hpp
+++ b/include/boost/burl/any_request_body.hpp
@@ -13,7 +13,7 @@
 #include <boost/burl/detail/config.hpp>
 #include <boost/burl/request_body.hpp>
 
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/capy/io_task.hpp>
 
 #include <cstdint>
@@ -59,7 +59,7 @@ class any_request_body
         content_length() const = 0;
 
         virtual capy::io_task<>
-        write(capy::any_buffer_sink& sink) const = 0;
+        write(http::any_buffer_sink& sink) const = 0;
     };
 
     template<RequestBody T>
@@ -85,7 +85,7 @@ class any_request_body
         }
 
         capy::io_task<>
-        write(capy::any_buffer_sink& sink) const override
+        write(http::any_buffer_sink& sink) const override
         {
             return body.write(sink);
         }
@@ -215,7 +215,7 @@ public:
         @return An awaitable yielding `(error_code)`.
     */
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         return impl_->write(sink);
     }

--- a/include/boost/burl/detail/parser.hpp
+++ b/include/boost/burl/detail/parser.hpp
@@ -15,7 +15,7 @@
 
 #include <boost/capy/buffers/buffer_copy.hpp>
 #include <boost/capy/buffers/buffer_param.hpp>
-#include <boost/capy/concept/buffer_source.hpp>
+#include <boost/http/concept/buffer_source.hpp>
 #include <boost/capy/io/any_read_stream.hpp>
 #include <boost/capy/io_task.hpp>
 #include <boost/capy/read.hpp>

--- a/include/boost/burl/request_body.hpp
+++ b/include/boost/burl/request_body.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/burl/detail/config.hpp>
 
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/capy/io_task.hpp>
 
 #include <concepts>
@@ -44,7 +44,7 @@ namespace burl
         @ref body_from_tag.
 */
 template<typename T>
-concept RequestBody = requires(T const& t, capy::any_buffer_sink& sink) {
+concept RequestBody = requires(T const& t, http::any_buffer_sink& sink) {
     { t.content_type() } -> std::same_as<std::optional<std::string>>;
     { t.content_length() } -> std::same_as<std::optional<std::uint64_t>>;
     { t.write(sink) } -> std::same_as<capy::io_task<>>;

--- a/include/boost/burl/response.hpp
+++ b/include/boost/burl/response.hpp
@@ -16,8 +16,8 @@
 #include <boost/burl/detail/response_parser.hpp>
 #include <boost/burl/error.hpp>
 #include <boost/burl/test/fwd.hpp>
-#include <boost/capy/io/any_buffer_source.hpp>
-#include <boost/capy/io/any_read_source.hpp>
+#include <boost/http/io/any_buffer_source.hpp>
+#include <boost/http/io/any_read_source.hpp>
 #include <boost/capy/io_task.hpp>
 #include <boost/corosio/timeout.hpp>
 #include <boost/http/fields_base.hpp>
@@ -416,7 +416,7 @@ public:
         @see @ref as_read_source.
     */
     BOOST_BURL_DECL
-    capy::any_buffer_source
+    http::any_buffer_source
     as_buffer_source() &;
 
     /** Return a read source for reading the body.
@@ -431,7 +431,7 @@ public:
         @see @ref as_buffer_source.
     */
     BOOST_BURL_DECL
-    capy::any_read_source
+    http::any_read_source
     as_read_source() &;
 };
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -265,7 +265,7 @@ client::execute_impl(
         sr.reset(&stream, &headers);
         if(request.body.has_value())
         {
-            capy::any_buffer_sink sink(&sr);
+            http::any_buffer_sink sink(&sr);
             if(auto [wec] = co_await request.body.write(sink); wec)
                 co_return { wec, {} };
         }

--- a/src/detail/send_file.cpp
+++ b/src/detail/send_file.cpp
@@ -14,7 +14,7 @@
 #include <boost/burl/error.hpp>
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/this_coro.hpp>
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/corosio/file_base.hpp>
 #include <boost/corosio/stream_file.hpp>
 
@@ -29,7 +29,7 @@ namespace detail
 
 capy::io_task<>
 send_file(
-    capy::any_buffer_sink& sink,
+    http::any_buffer_sink& sink,
     std::filesystem::path const& path,
     std::uint64_t size,
     bool call_eof)

--- a/src/detail/send_file.hpp
+++ b/src/detail/send_file.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_BURL_SRC_DETAIL_SEND_FILE_HPP
 #define BOOST_BURL_SRC_DETAIL_SEND_FILE_HPP
 
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/capy/io_task.hpp>
 
 #include <cstdint>
@@ -32,7 +32,7 @@ namespace detail
 // with error::file_changed if the file no longer holds `size` bytes.
 capy::io_task<>
 send_file(
-    capy::any_buffer_sink& sink,
+    http::any_buffer_sink& sink,
     std::filesystem::path const& path,
     std::uint64_t size,
     bool call_eof = false);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -12,8 +12,8 @@
 #include "detail/send_file.hpp"
 
 #include <boost/capy/ex/this_coro.hpp>
-#include <boost/capy/io/any_buffer_source.hpp>
-#include <boost/capy/io/push_to.hpp>
+#include <boost/http/io/any_buffer_source.hpp>
+#include <boost/http/io/push_to.hpp>
 #include <boost/corosio/file_base.hpp>
 #include <boost/corosio/stream_file.hpp>
 #include <boost/http/server/mime_types.hpp>
@@ -61,7 +61,7 @@ public:
     }
 
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         return detail::send_file(sink, path_, size_, true);
     }
@@ -94,7 +94,7 @@ tag_invoke(
     }
 
     auto src = resp.as_buffer_source();
-    auto [ec, n] = co_await capy::push_to(src, f);
+    auto [ec, n] = co_await http::push_to(src, f);
     co_return { ec, std::move(dest) };
 }
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -52,7 +52,7 @@ public:
     }
 
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         json::serializer sr;
         sr.reset(&value_);

--- a/src/multipart_form.cpp
+++ b/src/multipart_form.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/http/server/mime_types.hpp>
 
 #include <cstdint>
@@ -173,7 +173,7 @@ public:
     }
 
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         using capy::make_buffer;
 

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -87,16 +87,16 @@ response::as_view() &
     co_return std::move(body);
 }
 
-capy::any_buffer_source
+http::any_buffer_source
 response::as_buffer_source() &
 {
-    return capy::any_buffer_source(&parser_);
+    return http::any_buffer_source(&parser_);
 }
 
-capy::any_read_source
+http::any_read_source
 response::as_read_source() &
 {
-    return capy::any_read_source(&parser_);
+    return http::any_read_source(&parser_);
 }
 
 } // namespace burl

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -48,7 +48,7 @@ public:
     }
 
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         auto [ec, n] =
             co_await sink.write_eof(
@@ -80,7 +80,7 @@ public:
     }
 
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         auto [ec, n] = co_await sink.write_eof(
             capy::make_buffer(body_));

--- a/src/urlencoded_form.cpp
+++ b/src/urlencoded_form.cpp
@@ -10,7 +10,7 @@
 #include <boost/burl/urlencoded_form.hpp>
 
 #include <boost/capy/buffers/make_buffer.hpp>
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/url/encode.hpp>
 #include <boost/url/encoding_opts.hpp>
 #include <boost/url/rfc/unreserved_chars.hpp>
@@ -78,7 +78,7 @@ public:
     }
 
     capy::io_task<>
-    write(capy::any_buffer_sink& sink) const
+    write(http::any_buffer_sink& sink) const
     {
         auto [ec, n] = co_await sink.write_eof(
             capy::make_buffer(std::string_view(body_)));

--- a/test/unit/body_test.hpp
+++ b/test/unit/body_test.hpp
@@ -13,9 +13,9 @@
 #include <boost/burl/any_request_body.hpp>
 
 #include <boost/capy/ex/run_async.hpp>
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/capy/task.hpp>
-#include <boost/capy/test/buffer_sink.hpp>
+#include <boost/http/test/buffer_sink.hpp>
 #include <boost/capy/test/fuse.hpp>
 #include <boost/corosio/io_context.hpp>
 
@@ -37,8 +37,8 @@ check_body(
     BOOST_TEST(body.has_value());
     capy::test::fuse f;
     auto r = f.armed([&](capy::test::fuse& f) -> capy::task<> {
-        capy::test::buffer_sink bs(f);
-        capy::any_buffer_sink sink(&bs);
+        http::test::buffer_sink bs(f);
+        http::any_buffer_sink sink(&bs);
 
         auto [ec] = co_await body.write(sink);
         if(ec)
@@ -57,8 +57,8 @@ check_io_body(
 {
     corosio::io_context ioc;
     std::error_code ec;
-    capy::test::buffer_sink bs;
-    capy::any_buffer_sink sink(&bs);
+    http::test::buffer_sink bs;
+    http::any_buffer_sink sink(&bs);
     capy::run_async(
         ioc.get_executor(),
         [&](capy::io_result<> res) {ec = res.ec; })

--- a/test/unit/detail/send_file.cpp
+++ b/test/unit/detail/send_file.cpp
@@ -13,7 +13,7 @@
 #include <boost/burl/error.hpp>
 
 #include <boost/capy/ex/run_async.hpp>
-#include <boost/capy/test/buffer_sink.hpp>
+#include <boost/http/test/buffer_sink.hpp>
 #include <boost/corosio/io_context.hpp>
 
 #include "../temp_file.hpp"
@@ -32,11 +32,11 @@ class send_file_test
     static std::error_code
     run(std::filesystem::path const& path,
         std::uint64_t size,
-        capy::test::buffer_sink& bs)
+        http::test::buffer_sink& bs)
     {
         corosio::io_context ioc;
         std::error_code ret;
-        capy::any_buffer_sink sink(&bs);
+        http::any_buffer_sink sink(&bs);
         capy::run_async(
             ioc.get_executor(),
             [&](capy::io_result<> r) { ret = r.ec; })
@@ -52,7 +52,7 @@ public:
         std::string const contents = "hello file body";
         temp_file tmp(contents);
 
-        capy::test::buffer_sink bs;
+        http::test::buffer_sink bs;
         auto ec = run(tmp.path, contents.size(), bs);
 
         BOOST_TEST(!ec);
@@ -65,7 +65,7 @@ public:
         std::string const contents = "hello";
         temp_file tmp(contents);
 
-        capy::test::buffer_sink bs;
+        http::test::buffer_sink bs;
         auto ec = run(tmp.path, contents.size() + 10, bs);
 
         BOOST_TEST(ec == error::file_changed);
@@ -77,7 +77,7 @@ public:
         std::string const contents = "hello file body";
         temp_file tmp(contents);
 
-        capy::test::buffer_sink bs;
+        http::test::buffer_sink bs;
         auto ec = run(tmp.path, 5, bs);
 
         BOOST_TEST(!ec);

--- a/test/unit/urlencoded_form.cpp
+++ b/test/unit/urlencoded_form.cpp
@@ -13,9 +13,9 @@
 #include <boost/burl/any_request_body.hpp>
 #include <boost/burl/conversion.hpp>
 
-#include <boost/capy/io/any_buffer_sink.hpp>
+#include <boost/http/io/any_buffer_sink.hpp>
 #include <boost/capy/task.hpp>
-#include <boost/capy/test/buffer_sink.hpp>
+#include <boost/http/test/buffer_sink.hpp>
 #include <boost/capy/test/fuse.hpp>
 
 #include "test_suite.hpp"
@@ -53,8 +53,8 @@ struct urlencoded_form_test
             capy::test::fuse().armed(
                 [&](capy::test::fuse& f) -> capy::task<void>
                 {
-                    capy::test::buffer_sink bs(f);
-                    capy::any_buffer_sink sink(&bs);
+                    http::test::buffer_sink bs(f);
+                    http::any_buffer_sink sink(&bs);
 
                     auto [ec] = co_await body.write(sink);
                     if(ec)


### PR DESCRIPTION
push_to and the source/sink type-erased wrappers (any_buffer_source, any_buffer_sink, any_read_source) plus the BufferSource concept moved from capy to boost.http. Point burl's includes and qualifications at their new home: <boost/http/io/...>, <boost/http/concept/buffer_source.hpp>, and http:: instead of capy:: for those symbols.